### PR TITLE
refactor: Remove unused Image import from Sidebar component

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { Home, Users } from 'lucide-react';
-import Image from "next/image";
 
 interface SidebarProps {
     collapsed: boolean;


### PR DESCRIPTION
The `Image` component from `next/image` was imported in `src/components/layout/Sidebar.tsx` but not used. This commit removes the unused import to improve code cleanliness and reduce bundle size.